### PR TITLE
Final styling tweaks

### DIFF
--- a/web/app/app.component.ts
+++ b/web/app/app.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
     </div>
     <nav class="navbar-navbar-default">
       <div class = "container-fluid">
-          <a class = "navbar-left"routerLink="/story-editor" routerLinkActive="active">Story Editor</a>
+          <a class = "navbar-left"routerLink="/story-editor/1" routerLinkActive="active">Story Editor</a>
           <a class = "navbar-right" routerLink="/story-search" routerLinkActive="active">Story Search</a>
       </div>
     </nav>

--- a/web/app/story-detail.component.css
+++ b/web/app/story-detail.component.css
@@ -18,6 +18,7 @@ label {
   margin: .5em 0;
   color: #DA1E05;
   font-weight: bold;
+  margin-right: 5px;
 }
 input.editable{
   border: none;
@@ -46,11 +47,24 @@ button:disabled {
   color: #ccc;
   cursor: auto;
 }
+button.delete{
+  margin-top: 7px;
+  margin-bottom: 7px;
+  margin-left: 0px;
+  background-color: #DA1E05;
+  border: none;
+  font-family: 'Raleway', sans-serif;
+  font-size: 1em;
+  color: white;
+  cursor: pointer; cursor: hand;
+  padding: 10px;
 
+}
 h3, #title, #author, #event-time, #section, #created, #location, #author-job, #kicker, #issue, #photographer {
   font-family: 'Raleway', sans-serif;
   margin-right: 20px;
 }
+
 h3 {
   margin-top: 0;
   margin-bottom: 10px;

--- a/web/app/story-detail.component.html
+++ b/web/app/story-detail.component.html
@@ -9,9 +9,6 @@
       <input class = "editable" [(ngModel)]="story.title" (change) = "save()" placeholder="Title" />
     </div>
 
-  <!-- figure out how to save author and other new categories  -->
-  <!-- suggestion: new categories for details - author, author job, kicker, photographer, issue date. -->
-
     <div id = "section">
       <label>Section: </label>
       <input class = "editable" [(ngModel)]="story.section"(change) = "save()" placeholder="Section" />
@@ -50,10 +47,8 @@
     <div id = "created">
       <label>Created: </label>{{story.created | date:"short"}}
     </div>
+      <button class="delete" (click)="delete(story); $event.stopPropagation()">
+            Delete Story
+    </button> 
   </div>
-
-    <!-- ..................................... -->
-
-  <!-- <button (click)="goBack()">Back</button> -->
-<!--   <button (click)="save()">Save</button>
- --></div>
+ </div>

--- a/web/app/story-list.component.html
+++ b/web/app/story-list.component.html
@@ -5,31 +5,18 @@
         <input type="text" name = "search" placeholder="Search for or a current story, or add a story" style="width: 490px; height: 60px; font-size: 1em; font-family: 'Raleway', sans-serif;"
         #storyTitle />
 
+         <!-- change this to add only when there are no search results, add button should only come up when there are no search results -->
 
-         <!-- change this to add only when there are no search results, add button should only come up when there are no search results!! -->
-
-
-        <input type = "submit" value = "Add" (click)="add(storyTitle.value); storyTitle.value=''" class = "add-button">
+        <input type = "submit" value = "Add" (keyup.enter)="add(storyTitle.value); storyTitle.value=''" (click)="add(storyTitle.value); storyTitle.value=''" class = "add-button">
       </div>
       <ul class="stories">
-        <li class = "story" *ngFor="let story of stories" [class.selected]="story === selectedStory" (click)="onSelect(story)">
-
-          <!-- AUTOMATIC WAY TO IMPORT STORY'S PHOTO? -->
+        <li class = "story" *ngFor="let story of stories" [class.selected]="story === selectedStory" (click)="onSelect(story); gotoDetail()">
 
           <img class = "story-photo" src = "../pic.jpg" style= "width: 17%;">
           <div class = "info">
             <div class = "title"> {{story.title}} </div>
             <div class = "section"> {{story.section}} </div>
             <div class = "author"> Ana Wishnoff </div>
-            <button class="delete" (click)="delete(hero); $event.stopPropagation()">
-            delete story
-            </button>
-
-            <!-- Change an item's "active" state so that it doesn't have to be active for the user to see the details -->
-
-             <button (click)="gotoDetail()" class = "details">
-            see details
-            </button>
           </div>
 
 


### PR DESCRIPTION
Eliminated "see details" and "delete story" buttons underneath every story's entry to allow for a more smooth transition - when you click on a story, the right side of the screen immediately updates with the story in the editor and the story's details. Added a new, more visible delete button at the bottom of details panel. Also, fixed some minor bugs in the style that dealt with the editor width changing. 