### PR TITLE
Fix for oversized featured-photo

### DIFF
--- a/pipeline/static/css/pipeline.scss
+++ b/pipeline/static/css/pipeline.scss
@@ -258,8 +258,6 @@ ul.pagination {
 
 .img-container{
   width: 100%;
-  max-width: 768px;
-
 }
 
 .template-articlepage .featured-photo .meta {

--- a/pipeline/static/css/pipeline.scss
+++ b/pipeline/static/css/pipeline.scss
@@ -253,10 +253,11 @@ ul.pagination {
 
 .template-articlepage .featured-photo img {
   height: auto;
-  width: 100%;
+  width: 768px;
 }
 
 .img-container{
+  text-align: center;
   width: 100%;
 }
 


### PR DESCRIPTION
## Description
My last commit(#115) introduced a bug where the `featured-photo` at the head of articles with galleries was the full width of the page. This commit fixes that bug.

## Changes
Added a cap to the width of the `featured-photo` at the top of an articles, I used the same pixel width as was in the line that I removed in commit #115- this is the current value we use on the live site. I also added a line to center this div so the photo was centered.

## Related Issue
#93 
