### PR TITLE
Fix tags showing up in link descriptions 

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -399,7 +399,7 @@ class ArticlePage(RoutablePageMixin, Page):
     @route(r"^$")
     def post_404(self, request):
         """Return an HTTP 404 whenever the page is accessed directly.
-        
+
         This is because it should instead by accessed by its date-based path,
         i.e. `<year>/<month>/<slug>/`."""
         raise Http404
@@ -507,8 +507,9 @@ class ArticlePage(RoutablePageMixin, Page):
 
         # description: either the article's summary or first paragraph
         if self.summary is not None:
-            tags["og:description"] = self.summary
-            tags["twitter:description"] = self.summary
+            soup = BeautifulSoup(self.summary, "html.parser")
+            tags["og:description"] = soup.get_text()
+            tags["twitter:description"] = soup.get_text()
         else:
             first_chars = self.get_first_chars()
             if first_chars is not None:


### PR DESCRIPTION
### Changes
I used Beautiful Soup to strip the html tags out of the summary for both of the description tags.

I tested this using localtunnel and the Facebook sharing debugger tool.

### Related issue
#92 