### PR TITLE
temp fix for oversized inline images

### DIFF
--- a/pipeline/static/css/pipeline.scss
+++ b/pipeline/static/css/pipeline.scss
@@ -263,18 +263,18 @@ ul.pagination {
     img {
       width: 100%;
     }
-    .small img {
-      max-width: var(--breakpoint-sm);
-    }
-    .medium img {
-      max-width: var(--breakpoint-md);
-    }
-    .large img {
-      max-width: var(--breakpoint-xl);
-    }
-    .meta {
-      font-size: 0.9rem;
-    }
+  }
+  .small img {
+    max-width: var(--breakpoint-sm);
+  }
+  .medium img {
+    max-width: var(--breakpoint-md);
+  }
+  .large img {
+    max-width: var(--breakpoint-xl);
+  }
+  .meta {
+    font-size: 0.9rem;
   }
   .photo-gallery {
     padding: 0;


### PR DESCRIPTION
**Related Issues**
#132

**Describe the Changes**
moved the small, medium, and large tags outside of photo-block because the img wasnt getting `max-width:var(--breakpoint-**)`
 
**Still To Do**
find a perm fix since this applies the css to all of the img with tags `.template-articlepage .SIZE` where SIZE is small, medium, or large. Instead on the old site where it was only `.template-articlepage .photo-block .SIZE`.

**Problems**
See "Still To Do"

**Testing**
looked at an article page with the blocks effected. as well as around the site.

