### PR TITLE
fix: Update Dockerfile

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,5 +2,6 @@ FROM nginx:1.15
 LABEL maintainer="web@poly.rpi.edu"
 
 COPY nginx.conf /etc/nginx/nginx.conf
+RUN mkdir /var/log/nginx
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Making sure that the directory needed for logs is created. This caused issues on the live machine website.

**Related Issues**
Broken Nginx error:
`nginx: [alert] could not open error log file: open() "/var/log/nginx"`
`Failed to start A high performance web server and a reverse proxy server.`

**Describe the Changes**
Added a line to the docker file to make sure the directory is created.

**Problems**
Not sure if this creates issues if the directory already exists or it just skips.

**Testing**
No testing was done. This change was the same command ran on the live version.


