### PR TITLE
Home page blocks

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -18,7 +18,6 @@ class ArticleBlock(blocks.StructBlock):
     help_text="Optional. Ovverides the image on the post.",
     required=False
     )
-    # TODO: add a "hide photo" block
 
     class Meta:
         template = "home/article_block.html"

--- a/home/models.py
+++ b/home/models.py
@@ -2,6 +2,7 @@ from wagtail.core.models import Page
 from wagtail.core.fields import StreamField
 from wagtail.admin.edit_handlers import StreamFieldPanel
 from wagtail.core import blocks
+from wagtail.images.blocks import ImageChooserBlock
 
 from core.models import ArticlePage, ArticlesIndexPage, AdBlock, MarqueeBlock
 
@@ -11,7 +12,12 @@ class ArticleBlock(blocks.StructBlock):
     headline = blocks.RichTextBlock(
         help_text="Optional. Will override the article's headline.", required=False
     )
-    # TODO: add a photo override block
+
+    # Image override block.
+    image = ImageChooserBlock(
+    help_text="Optional. Ovverides the image on the post.",
+    required=False
+    )
     # TODO: add a "hide photo" block
 
     class Meta:

--- a/home/templates/home/article.html
+++ b/home/templates/home/article.html
@@ -16,7 +16,13 @@
             <strong class="d-inline-block mb-0 text-primary text-uppercase text-kicker">{{ article.kicker }}</strong>
         {% endif %}
         <h3 class="mb-2 headline">
-            <a class="text-dark" href="{% pageurl article %}">{{ article.headline|richtext_unwrapped }}</a>
+            <a class="text-dark" href="{% pageurl article %}">
+            	{% if block_headline %}
+			{{ block_headline }}
+            	{% else %}	
+            		{{ article.headline|richtext_unwrapped }}
+            	{% endif %}
+            </a>
         </h3>
         <div class="card-text mb-auto summary">{{ article.summary|richtext }}</div>
     </div>

--- a/home/templates/home/article.html
+++ b/home/templates/home/article.html
@@ -2,8 +2,12 @@
 
 <div class="flex-md-row">
     <div class="d-flex flex-column align-items-start">
-        {% if article.featured_image %}
-            {% image article.featured_image width-1200 as photo %}
+        {% if block_image or article.featured_image %}
+            {% if block_image %}
+                {% image block_image width-1200 as photo %}
+            {% elif article.featured_image %}
+                {% image article.featured_image width-1200 as photo %}
+            {% endif %}
             <a href="{% pageurl article %}">
                 <img class="img-fluid mb-2 mb-md-3" src="{{ photo.url }}">
             </a>

--- a/home/templates/home/article_block.html
+++ b/home/templates/home/article_block.html
@@ -1,3 +1,3 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% include "home/article.html" with article=value.article only %}
+{% include "home/article.html" with article=value.article block_image=value.image only%}

--- a/home/templates/home/article_block.html
+++ b/home/templates/home/article_block.html
@@ -1,3 +1,3 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% include "home/article.html" with article=value.article block_image=value.image only%}
+{% include "home/article.html" with article=value.article block_image=value.image block_headline=value.headline only%}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -55,7 +55,11 @@
                         <div class="lead d-none d-lg-block">{{ block.value.column.article.specific.summary|richtext }}</div>
                     </div>
                     <div class="col-lg-5">
-                        {% image block.value.column.article.featured_image width-1200 as photo %}
+                    	{% if block.value.column.image %}
+                    	    {% image block.value.column.image width-1200 as photo %}
+                    	{% else %}
+                           {% image block.value.column.article.featured_image width-1200 as photo %}
+                        {% endif %}
                         <a href="{% pageurl block.value.column.article %}">
                             <img class="img-fluid mb-3" src="{{ photo.url }}">
                         </a>

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -43,7 +43,11 @@
                 {% endif %}
             {% elif block.block_type == "one_column" %}
                 <div class="featured border-md-bottom pb-1 mb-5 mb-md-0 d-lg-flex">
-                    <div class="col-lg-7">
+                    {% if block.value.column.image or block.value.column.article.featured_image %}
+                    	<div class="col-lg-7">
+                    {% else %}
+			<div class="col-lg-12">
+                    {% endif %}
                         {% if block.value.column.article.specific.kicker %}
                             <strong class="text-primary text-uppercase text-kicker">{{ block.value.column.article.specific.kicker }}</strong>
                         {% endif %}
@@ -54,16 +58,18 @@
                         </h1>
                         <div class="lead d-none d-lg-block">{{ block.value.column.article.specific.summary|richtext }}</div>
                     </div>
+                    {% if block.value.column.image or block.value.column.article.featured_image %}
                     <div class="col-lg-5">
                     	{% if block.value.column.image %}
                     	    {% image block.value.column.image width-1200 as photo %}
                     	{% else %}
                            {% image block.value.column.article.featured_image width-1200 as photo %}
-                        {% endif %}
+                       {% endif %}
                         <a href="{% pageurl block.value.column.article %}">
                             <img class="img-fluid mb-3" src="{{ photo.url }}">
                         </a>
                     </div>
+                    {% endif %}
                     <div class="col-lg-7 d-lg-none">
                         <div class="lead">{{ block.value.column.article.specific.summary|richtext }}</div>
                     </div>

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -53,7 +53,11 @@
                         {% endif %}
                         <h1 class="display-4 mb-3">
                             <a class="text-dark" href="{% pageurl block.value.column.article %}">
-                                {{ block.value.column.article.specific.headline|richtext_unwrapped }}
+                                {% if block.value.column.headline %}
+                                	{{ block.value.column.headline }}
+                                {% else %}
+                                	{{ block.value.column.article.specific.headline|richtext_unwrapped }}
+                                {% endif %}
                             </a>
                         </h1>
                         <div class="lead d-none d-lg-block">{{ block.value.column.article.specific.summary|richtext }}</div>


### PR DESCRIPTION
**Related Issues**
This dealt with the empty spacing on the homepage when no image was published with the article.

**Describe the Changes**
I have added an image override block to the article block model to allow for overriding of an image in any article.
I have also added changes to the templates to allow for checks for images. 

**Still To Do**
There should be an option to allow for centering the span rather than just spanning the entire row.

**Problems**
No problems were discovered.

**Testing**
The main testing done was for UI. Check if the layout is proper and check whether or not the image block is there.

