### PR TITLE
Order contributors by name

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -72,6 +72,9 @@ class Contributor(index.Indexed, models.Model):
     search_fields = [index.SearchField("name", partial_match=True)]
 
     autocomplete_search_field = "name"
+    
+    class Meta:
+        ordering = ['name']
 
     def autocomplete_label(self):
         return self.name


### PR DESCRIPTION
**Related Issues**
Solves #191 

**Describe the Changes**
Adds a meta class to order Contributors database by name.

**Testing**
- Create contributors in "snippets"
- Go to any article page, go to "choose an image" -> "upload" -> "photographers"
- The dropdown list *should* be ordered

**Preview**
![](https://i.imgur.com/Jd0tmaC.png)