### PR TITLE
Remove extraneous HTML tags from RSS feed titles

### DIFF
--- a/core/feeds.py
+++ b/core/feeds.py
@@ -10,7 +10,7 @@ class RecentArticlesFeed(Feed):
         return ArticlePage.objects.live().order_by("-first_published_at")[:20]
 
     def item_title(self, item):
-        return item.headline
+        return item.title
 
     def item_description(self, item):
         return item.body

--- a/core/tests.py
+++ b/core/tests.py
@@ -45,7 +45,7 @@ class RecentArticlesFeedTest(TestCase):
         item = root[0].find("item")
         self.assertIsNot(item, None)
 
-        self.assertEqual(item.find("title").text, page.headline)
+        self.assertEqual(item.find("title").text, page.title)
         self.assertEqual(item.find("description").text, str(page.body))
         self.assertEqual(item.find("link").text, page.full_url)
         self.assertEqual(


### PR DESCRIPTION
**Related Issues**

I wrote this bug back in 2018: https://github.com/thepoly/pipeline/pull/82

**Describe the Changes**

In my RSS reader pointed at https://poly.rpi.edu/feed/ I see articles with titles like this:

<img width="406" alt="Screenshot 2023-02-05 at 6 43 52 PM" src="https://user-images.githubusercontent.com/335234/216871610-cc0d1bb5-1acf-42d3-82e4-c8058c9dd937.png">

Pipeline already "cleans" the headline to get a tag-free title: https://github.com/thepoly/pipeline/blob/939e15b9c36ef88f4f41f72026f23988f64481ea/core/models.py#L500-L501

This change causes Pipeline to return that cleaned title instead, which eliminates the extraneous tags in the titles of RSS items.

**Still To Do**

Nothing.

**Problems**

None known.

**Testing**

1. Ran Pipeline in Docker according the readme
2. Ran `python manage.py test` to make sure my test case passes
3. Created a test article
4. Requested the feed and observed the cleaned title:
```
~/S/pipeline (master)> http :8000/feed/
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 702
Content-Type: application/rss+xml; charset=utf-8
Date: Mon, 06 Feb 2023 02:39:02 GMT
Last-Modified: Mon, 06 Feb 2023 02:38:54 GMT
Server: nginx/1.15.12
X-Frame-Options: SAMEORIGIN

<?xml version="1.0" encoding="utf-8"?>
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
  <channel>
    <title>The Polytechnic</title>
    <link>http://localhost/</link>
    <description/>
    <atom:link href="http://localhost/feed/" rel="self"/>
    <language>en-us</language>
    <lastBuildDate>Mon, 06 Feb 2023 02:38:54 +0000</lastBuildDate>
    <item>
      <title>Hey! This shouldn't have any tags now</title>
      <link>http://localhost/2023/02/boop/</link>
      <description>&lt;div class=&quot;block-paragraph&quot;&gt;&lt;div class=&quot;rich-text&quot;&gt;&lt;p&gt;boop&lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</description>
      <pubDate>Mon, 06 Feb 2023 02:38:54 +0000</pubDate>
      <guid>http://localhost/2023/02/boop/</guid>
    </item>
  </channel>
</rss>
```
